### PR TITLE
[Hotfix] 9006 에러 코드 처리 추가 및 client_id 재생성 워크어라운드 확장

### DIFF
--- a/wideq/__init__.py
+++ b/wideq/__init__.py
@@ -8,5 +8,5 @@ from .dryer import *  # noqa
 from .refrigerator import *  # noqa
 from .washer import *  # noqa
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 

--- a/wideq/core.py
+++ b/wideq/core.py
@@ -194,7 +194,7 @@ class InvalidRequestError(APIError):
 
 
 class UseOfficialAPIError(APIError):
-    """Server suggests using the official public API (error 9012)."""
+    """Server suggests using the official public API (error 9006, 9012)."""
 
 
 class DeviceNotFoundError:
@@ -225,6 +225,7 @@ API_ERRORS = {
     "0110": InvalidCredentialError,
     9000: InvalidRequestError,  # Surprisingly, an integer (not a string).
     9003: NotLoggedInError,  # Session Creation FailureError
+    "9006": UseOfficialAPIError,
     "9012": UseOfficialAPIError,
 }
 
@@ -495,9 +496,9 @@ class Session(object):
         self.client_id = client_id
 
     def refresh_client_id(self):
-        """Regenerate client_id as a workaround for error 9012."""
+        """Regenerate client_id as a workaround for error 9006, 9012."""
         self.client_id = _gen_client_id()
-        LOGGER.info("Refreshed client_id after 9012 error")
+        LOGGER.info("Refreshed client_id after 9006, 9012 error")
         return self.client_id
 
     def post(self, path, data=None):


### PR DESCRIPTION
## What is this PR? 🔍
- 9012와 동일하게 동작하는 9006 에러 코드를 UseOfficialAPIError로 매핑하여, 기존 client_id 재생성 재시도 로직이 9006에도 자동 적용되도록 수정

## Changes ✍️
- wideq/core.py의 API_ERRORS 딕셔너리에 "9006": UseOfficialAPIError 매핑 추가
- UseOfficialAPIError 클래스 docstring을 error 9006, 9012 동시 표기로 갱신
- Session.refresh_client_id() docstring과 로그 메시지를 9006, 9012로 갱신하여 두 에러 모두 워크어라운드 대상임을 명시
- wideq/__init__.py 버전 2.1.1 → 2.1.2로 bump